### PR TITLE
changed PORT to TCP_PORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-PORT=
+TCP_PORT=
 JSON_PATH=


### PR DESCRIPTION
There is a small error in the connecting the tcp port. In index.js, the socket is binding the port via process.env.TCP_PORT. But in .env, instead of TCP_PORT, it is just PORT. The difference in the names cause issue in establishing connection in the localhost on my laptop. I just change the PORT in .env and .env.sample to TCP_PORT.